### PR TITLE
docs: add accent to installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587
 EMAIL_USER=tu_correo@gmail.com
 EMAIL_PASS=contraseña_app_gmail
-⚠️ Asegurate de tener habilitada la opción de "Contraseñas de aplicaciones" en Gmail.
+⚠️ Asegúrate de tener habilitada la opción de "Contraseñas de aplicaciones" en Gmail.
 4. Ejecutar el proyecto
 Backend
 cd backend


### PR DESCRIPTION
## Summary
- fix accent in installation instruction

## Testing
- `npm test` (fails: no test specified)
- `npm run lint` (fails: 1 error, 3 warnings)

------
https://chatgpt.com/codex/tasks/task_e_689254fd4fd483258c9feb81421244f6