### PR TITLE
Add auth middleware tests and Jest configuration

### DIFF
--- a/inmobiliaria-backend/package.json
+++ b/inmobiliaria-backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node index.js",
     "dev": "nodemon index.js"
   },
@@ -23,6 +23,11 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/inmobiliaria-backend/tests/auth.middleware.test.js
+++ b/inmobiliaria-backend/tests/auth.middleware.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const verifyToken = require('../middlewares/auth.middleware');
+
+const SECRET_KEY = 'secreto-super-seguro';
+
+describe('Auth middleware', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.get('/protected', verifyToken, (req, res) => {
+      res.status(200).json({ message: 'ok' });
+    });
+  });
+
+  test('Missing Authorization header -> 403 response', async () => {
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Token no proporcionado' });
+  });
+
+  test('Invalid token -> 401 response', async () => {
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer invalid');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Token inválido o expirado' });
+  });
+
+  test('Valid token -> request proceeds via next', () => {
+    const token = jwt.sign({ id: 1 }, SECRET_KEY);
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+
+    verifyToken(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add auth middleware tests for missing/invalid/valid tokens
- configure Jest test runner and dependencies

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925848cc0883258b3b24eb8fab7a7d