### PR TITLE
docs: close installation code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Este proyecto es una aplicación web completa para la gestión de propiedades in
 ```bash
 git clone https://github.com/tu-usuario/inmobiliaria-web.git
 cd inmobiliaria-web
+```
+
 2. Instalar dependencias
 Backend
 cd backend


### PR DESCRIPTION
## Summary
- close missing triple backtick in installation section of README so numbered steps render normally

## Testing
- `cd inmobiliaria-backend && npm test`
- `cd inmobiliaria-frontend && npm test` *(fails: Missing script "test")*
- `cd inmobiliaria-frontend && npm run lint` *(fails: err is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_689260daf6908325bdbbe11be1494a83