### PR TITLE
feat: add health check endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/node_modules/
+**/.env
+**/uploads/

--- a/inmobiliaria-backend/index.js
+++ b/inmobiliaria-backend/index.js
@@ -12,6 +12,7 @@ const PORT = process.env.PORT || 3001;
 const propiedadRoutes = require('./routes/propiedad.routes');
 const usuarioRoutes = require('./routes/usuario.routes');
 const mensajeRoutes = require('./routes/mensaje.routes');
+const healthRoutes = require('./routes/health.routes');
 
 
 // Middlewares
@@ -23,6 +24,7 @@ app.use('/uploads', express.static(path.join(__dirname, 'uploads'))); // Carpeta
 app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/propiedades', propiedadRoutes);
 app.use('/api/mensajes', mensajeRoutes);
+app.use('/api/health', healthRoutes);
 
 // Iniciamos el servidor
 app.listen(PORT, () => {

--- a/inmobiliaria-backend/routes/health.routes.js
+++ b/inmobiliaria-backend/routes/health.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+module.exports = router;

--- a/inmobiliaria-backend/tests/health.routes.test.js
+++ b/inmobiliaria-backend/tests/health.routes.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const express = require('express');
+const healthRoutes = require('../routes/health.routes');
+
+describe('GET /api/health', () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use('/api/health', healthRoutes);
+  });
+
+  test('responds with status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "inmobiliaria-backend/index.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "inmobiliaria-backend/index.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint
- ignore generated files
- configure Vercel builds and routing

## Testing
- `npm --prefix inmobiliaria-backend test`


------
https://chatgpt.com/codex/tasks/task_e_68926338cdc083259c84c69059c97b8b