### PR TITLE
Configure Netlify build for frontend and fix lint warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,9 @@ cd ../frontend
 npm run dev
 👨‍💻 Autor
 Diego Alaye
+
+---
+
+### Despliegue del frontend en Netlify
+
+El archivo `netlify.toml` configura la carpeta `inmobiliaria-frontend` para que Netlify ejecute `npm run build` y publique el contenido de `dist`. De esta manera, los archivos JavaScript se sirven con el tipo MIME correcto y se evita la pantalla en blanco al cargar el sitio.

--- a/inmobiliaria-frontend/src/components/RutaPrivadaAdmin.jsx
+++ b/inmobiliaria-frontend/src/components/RutaPrivadaAdmin.jsx
@@ -19,7 +19,7 @@ function RutaPrivadaAdmin({ children }) {
     try {
       const userData = JSON.parse(usuario);
       setAutorizado(userData.rol === 'admin');
-    } catch (err) {
+    } catch {
       setAutorizado(false);
     } finally {
       setValidando(false);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+base = "inmobiliaria-frontend"
+command = "npm run build"
+publish = "dist"


### PR DESCRIPTION
## Summary
- add Netlify configuration to build and publish the frontend
- document Netlify deployment in README
- remove unused error variable in `RutaPrivadaAdmin` to satisfy lint

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend)
- `npm test` (backend)
- `npm run lint` (backend) *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68928ee7205083258a48a37fb071113f