### PR TITLE
Truncate long descriptions on home page

### DIFF
--- a/inmobiliaria-frontend/src/pages/Home.jsx
+++ b/inmobiliaria-frontend/src/pages/Home.jsx
@@ -32,14 +32,14 @@ function Home() {
       </Typography>
 
       {Array.isArray(propiedades) && propiedades.length > 0 ? (
-        <Grid container spacing={4} justifyContent="center">
+        <Grid container spacing={4} justifyContent="center" alignItems="stretch">
           {propiedades.map((prop) => (
-            <Grid item key={prop.id} xs={12} sm={6} md={4}>
+            <Grid item key={prop.id} xs={12} sm={6} md={4} sx={{ display: "flex" }}>
               <Card
                 sx={{
-                  height: "100%",
                   display: "flex",
                   flexDirection: "column",
+                  flexGrow: 1,
                   borderRadius: 2,
                   boxShadow: 3,
                 }}
@@ -49,12 +49,24 @@ function Home() {
                   height="200"
                   image={prop.imagen_destacada}
                   alt={prop.titulo}
+                  sx={{ objectFit: "cover" }}
                 />
                 <CardContent sx={{ flexGrow: 1 }}>
                   <Typography variant="h6" gutterBottom>
                     {prop.titulo}
                   </Typography>
-                  <Typography variant="body2" color="text.secondary" paragraph>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    paragraph
+                    sx={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: "vertical",
+                    }}
+                  >
                     {prop.descripcion}
                   </Typography>
                   <Typography variant="body1">


### PR DESCRIPTION
## Summary
- trim long property descriptions to three lines with ellipsis
- ensure property card images keep their aspect ratio
- arrange property cards in a responsive 2–3 column grid for a symmetrical layout

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68978f72985c8325b5318b3084b74be1