### PR TITLE
Add footer component to frontend

### DIFF
--- a/inmobiliaria-frontend/src/App.jsx
+++ b/inmobiliaria-frontend/src/App.jsx
@@ -11,10 +11,11 @@ import NotFound from './pages/NotFound';
 import Navbar from './components/Navbar';
 import RutaPrivadaAdmin from './components/RutaPrivadaAdmin'; // Protege rutas de acceso solo para admins
 import VerificarCuenta from './pages/VerificarCuenta';
-import UsuariosAdmin from './pages/UsuariosAdmin'; 
+import UsuariosAdmin from './pages/UsuariosAdmin';
 import MensajesAdmin from './pages/MensajesAdmin';
 import RecuperarPassword from './pages/RecuperarPassword';
 import RestablecerPassword from './pages/RestablecerPassword';
+import Footer from './components/Footer';
 
 // Función principal del componente App
 function App({ setModo, modo }) {
@@ -45,6 +46,7 @@ function App({ setModo, modo }) {
         {/* Ruta para manejar páginas no encontradas */}
         <Route path="*" element={<NotFound />} />
       </Routes>
+      <Footer />
     </BrowserRouter>
   );
 }

--- a/inmobiliaria-frontend/src/components/Footer.jsx
+++ b/inmobiliaria-frontend/src/components/Footer.jsx
@@ -1,0 +1,22 @@
+import { Box, Typography } from "@mui/material";
+
+function Footer() {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        bgcolor: "primary.main",
+        color: "primary.contrastText",
+        p: 2,
+        mt: 4,
+        textAlign: "center",
+      }}
+    >
+      <Typography variant="body2">
+        © {new Date().getFullYear()} Inmobiliaria. Todos los derechos reservados.
+      </Typography>
+    </Box>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add a simple MUI-based footer
- display footer across pages via App router

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c1961c588325a972eacaec6097fa