### PR TITLE
feat: add property search filters

### DIFF
--- a/inmobiliaria-backend/controllers/propiedad.controller.js
+++ b/inmobiliaria-backend/controllers/propiedad.controller.js
@@ -4,9 +4,17 @@ const path = require("path");
 const supabase = require("../config/supabase");
 
 // GET /api/propiedades
-// Obtener todas las propiedades
+// Obtener todas las propiedades con filtros opcionales
 const obtenerPropiedades = (req, res) => {
-  Propiedad.getTodasLasPropiedades((err, resultados) => {
+  const filtros = {
+    ciudad: req.query.ciudad,
+    minPrecio: req.query.minPrecio,
+    maxPrecio: req.query.maxPrecio,
+    tipo: req.query.tipo,
+    ambientes: req.query.ambientes,
+  };
+
+  Propiedad.getTodasLasPropiedades(filtros, (err, resultados) => {
     if (err) {
       res.status(500).json({ error: "Error al obtener propiedades" });
     } else {

--- a/inmobiliaria-backend/models/propiedad.model.js
+++ b/inmobiliaria-backend/models/propiedad.model.js
@@ -2,10 +2,35 @@
 const db = require('../config/db');
 
 /**
- * Obtener todas las propiedades registradas
+ * Obtener todas las propiedades registradas con filtros opcionales
  */
-const getTodasLasPropiedades = (callback) => {
-  db.query('SELECT * FROM propiedades', callback);
+const getTodasLasPropiedades = (filtros = {}, callback) => {
+  let sql = 'SELECT * FROM propiedades WHERE 1=1';
+  const valores = [];
+  let idx = 1;
+
+  if (filtros.ciudad) {
+    sql += ` AND LOWER(ciudad) LIKE LOWER($${idx++})`;
+    valores.push(`%${filtros.ciudad}%`);
+  }
+  if (filtros.minPrecio) {
+    sql += ` AND precio >= $${idx++}`;
+    valores.push(filtros.minPrecio);
+  }
+  if (filtros.maxPrecio) {
+    sql += ` AND precio <= $${idx++}`;
+    valores.push(filtros.maxPrecio);
+  }
+  if (filtros.tipo) {
+    sql += ` AND tipo = $${idx++}`;
+    valores.push(filtros.tipo);
+  }
+  if (filtros.ambientes) {
+    sql += ` AND ambientes >= $${idx++}`;
+    valores.push(filtros.ambientes);
+  }
+
+  db.query(sql, valores, callback);
 };
 
 /**

--- a/inmobiliaria-frontend/src/pages/Home.jsx
+++ b/inmobiliaria-frontend/src/pages/Home.jsx
@@ -9,20 +9,39 @@ import {
   CardActions,
   Button,
   Grid,
+  TextField,
 } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 
 function Home() {
   const [propiedades, setPropiedades] = useState([]);
+  const [ciudad, setCiudad] = useState("");
+  const [tipo, setTipo] = useState("");
+  const [minPrecio, setMinPrecio] = useState("");
+  const [maxPrecio, setMaxPrecio] = useState("");
+  const [ambientes, setAmbientes] = useState("");
 
-  useEffect(() => {
+  const fetchPropiedades = () => {
+    const params = {};
+    if (ciudad) params.ciudad = ciudad;
+    if (tipo) params.tipo = tipo;
+    if (minPrecio) params.minPrecio = minPrecio;
+    if (maxPrecio) params.maxPrecio = maxPrecio;
+    if (ambientes) params.ambientes = ambientes;
+
     axios
-      .get("https://inmobiliaria-proyecto.onrender.com/api/propiedades")
+      .get("https://inmobiliaria-proyecto.onrender.com/api/propiedades", {
+        params,
+      })
       .then((res) => {
         console.log("Respuesta del backend:", res.data);
         setPropiedades(res.data);
       })
       .catch((err) => console.error("Error al cargar propiedades:", err));
+  };
+
+  useEffect(() => {
+    fetchPropiedades();
   }, []);
 
   return (
@@ -30,6 +49,49 @@ function Home() {
       <Typography variant="h4" component="h1" gutterBottom textAlign="center">
         Propiedades Disponibles
       </Typography>
+
+      {/* Filtros */}
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 2,
+          mb: 4,
+          justifyContent: "center",
+        }}
+      >
+        <TextField
+          label="Ciudad"
+          value={ciudad}
+          onChange={(e) => setCiudad(e.target.value)}
+        />
+        <TextField
+          label="Tipo de Propiedad"
+          value={tipo}
+          onChange={(e) => setTipo(e.target.value)}
+        />
+        <TextField
+          label="Precio Mínimo"
+          type="number"
+          value={minPrecio}
+          onChange={(e) => setMinPrecio(e.target.value)}
+        />
+        <TextField
+          label="Precio Máximo"
+          type="number"
+          value={maxPrecio}
+          onChange={(e) => setMaxPrecio(e.target.value)}
+        />
+        <TextField
+          label="Ambientes"
+          type="number"
+          value={ambientes}
+          onChange={(e) => setAmbientes(e.target.value)}
+        />
+        <Button variant="contained" onClick={fetchPropiedades}>
+          Buscar
+        </Button>
+      </Box>
 
       {Array.isArray(propiedades) && propiedades.length > 0 ? (
         <Grid container spacing={4} justifyContent="center" alignItems="stretch">


### PR DESCRIPTION
## Summary
- add backend query filtering for properties
- add filter inputs on home page to search by city, price, type and rooms

## Testing
- `cd inmobiliaria-backend && npm test`
- `cd inmobiliaria-frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c40658748325b5b1f05d6545789a