### PR TITLE
fix: include prop-types in build

### DIFF
--- a/inmobiliaria-frontend/vite.config.js
+++ b/inmobiliaria-frontend/vite.config.js
@@ -5,10 +5,4 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: "/",
-  build: {
-    rollupOptions: {
-      // externalize missing peer dependency to avoid bundling errors
-      external: ['prop-types'],
-    },
-  },
 })


### PR DESCRIPTION
## Summary
- bundle `prop-types` with frontend build to prevent runtime import failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bbc007e048325bd2c55bfa860cf3b