### PR TITLE
fix: include prop-types and admin API calls

### DIFF
--- a/inmobiliaria-frontend/src/pages/MensajesAdmin.jsx
+++ b/inmobiliaria-frontend/src/pages/MensajesAdmin.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../config/axios.js";
 import {
   Box,
   Typography,
@@ -19,8 +19,8 @@ function MensajesAdmin() {
   const token = localStorage.getItem("token");
 
   const cargarMensajes = () => {
-    axios
-      .get("https://inmobiliaria-proyecto.onrender.com/api/mensajes", {
+    api
+      .get("/mensajes", {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setMensajes(res.data))
@@ -31,8 +31,8 @@ function MensajesAdmin() {
   };
 
   const handleEliminarMensaje = (id) => {
-    axios
-      .delete(`https://inmobiliaria-proyecto.onrender.com/api/mensajes/${id}`, {
+    api
+      .delete(`/mensajes/${id}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then(() => cargarMensajes())

--- a/inmobiliaria-frontend/src/pages/UsuariosAdmin.jsx
+++ b/inmobiliaria-frontend/src/pages/UsuariosAdmin.jsx
@@ -1,6 +1,6 @@
 // src/pages/UsuariosAdmin.jsx
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../config/axios.js';
 import {
   Box,
   Typography,
@@ -23,13 +23,13 @@ function UsuariosAdmin() {
   const headers = { Authorization: `Bearer ${token}` };
 
   const cargarUsuarios = () => {
-    axios.get('https://inmobiliaria-proyecto.onrender.com/api/usuarios', { headers })
+    api.get('/usuarios', { headers })
       .then((res) => setUsuarios(res.data))
       .catch(() => setSnackbar({ open: true, mensaje: 'Error al cargar usuarios', tipo: 'error' }));
   };
 
   const cambiarRol = (id, nuevoRol) => {
-    axios.patch(`https://inmobiliaria-proyecto.onrender.com/api/usuarios/rol/${id}`, { rol: nuevoRol }, { headers })
+    api.patch(`/usuarios/rol/${id}`, { rol: nuevoRol }, { headers })
       .then(() => {
         setSnackbar({ open: true, mensaje: 'Rol actualizado', tipo: 'success' });
         cargarUsuarios();
@@ -38,7 +38,7 @@ function UsuariosAdmin() {
   };
 
   const cambiarEstado = (id, nuevoEstado) => {
-    axios.patch(`https://inmobiliaria-proyecto.onrender.com/api/usuarios/estado/${id}`, { activo: nuevoEstado }, { headers })
+    api.patch(`/usuarios/estado/${id}`, { activo: nuevoEstado }, { headers })
       .then(() => {
         setSnackbar({ open: true, mensaje: 'Estado actualizado', tipo: 'success' });
         cargarUsuarios();

--- a/inmobiliaria-frontend/vite.config.js
+++ b/inmobiliaria-frontend/vite.config.js
@@ -5,10 +5,4 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: "/",
-  build: {
-    rollupOptions: {
-      // externalize missing peer dependency to avoid bundling errors
-      external: ['prop-types'],
-    },
-  },
 })


### PR DESCRIPTION
## Summary
- bundle `prop-types` with frontend build to prevent runtime import failures
- route admin user/message requests through configured axios instance

## Testing
- `npm test` (frontend; fails: Missing script)
- `npm run lint`
- `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_e_689bbc007e048325bd2c55bfa860cf3b