### PR TITLE
fix: include prop-types and admin API calls

### DIFF
--- a/inmobiliaria-frontend/src/config/axios.js
+++ b/inmobiliaria-frontend/src/config/axios.js
@@ -4,4 +4,26 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'https://inmobiliaria-proyecto.onrender.com/api',
 });
 
+// Attach token from localStorage to each request
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// Redirect to login when the token is invalid or expired
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('usuario');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/inmobiliaria-frontend/src/pages/MensajesAdmin.jsx
+++ b/inmobiliaria-frontend/src/pages/MensajesAdmin.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../config/axios.js";
 import {
   Box,
   Typography,
@@ -16,13 +16,9 @@ function MensajesAdmin() {
   const [mensajes, setMensajes] = useState([]);
   const [error, setError] = useState("");
 
-  const token = localStorage.getItem("token");
-
   const cargarMensajes = () => {
-    axios
-      .get("https://inmobiliaria-proyecto.onrender.com/api/mensajes", {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+    api
+      .get("/mensajes")
       .then((res) => setMensajes(res.data))
       .catch((err) => {
         console.error("Error al obtener mensajes", err);
@@ -31,10 +27,8 @@ function MensajesAdmin() {
   };
 
   const handleEliminarMensaje = (id) => {
-    axios
-      .delete(`https://inmobiliaria-proyecto.onrender.com/api/mensajes/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+    api
+      .delete(`/mensajes/${id}`)
       .then(() => cargarMensajes())
       .catch(() => alert("Error al eliminar mensaje"));
   };

--- a/inmobiliaria-frontend/src/pages/UsuariosAdmin.jsx
+++ b/inmobiliaria-frontend/src/pages/UsuariosAdmin.jsx
@@ -1,6 +1,6 @@
 // src/pages/UsuariosAdmin.jsx
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../config/axios.js';
 import {
   Box,
   Typography,
@@ -19,17 +19,14 @@ function UsuariosAdmin() {
   const [usuarios, setUsuarios] = useState([]);
   const [snackbar, setSnackbar] = useState({ open: false, mensaje: '', tipo: 'success' });
 
-  const token = localStorage.getItem('token');
-  const headers = { Authorization: `Bearer ${token}` };
-
   const cargarUsuarios = () => {
-    axios.get('https://inmobiliaria-proyecto.onrender.com/api/usuarios', { headers })
+    api.get('/usuarios')
       .then((res) => setUsuarios(res.data))
       .catch(() => setSnackbar({ open: true, mensaje: 'Error al cargar usuarios', tipo: 'error' }));
   };
 
   const cambiarRol = (id, nuevoRol) => {
-    axios.patch(`https://inmobiliaria-proyecto.onrender.com/api/usuarios/rol/${id}`, { rol: nuevoRol }, { headers })
+    api.patch(`/usuarios/rol/${id}`, { rol: nuevoRol })
       .then(() => {
         setSnackbar({ open: true, mensaje: 'Rol actualizado', tipo: 'success' });
         cargarUsuarios();
@@ -38,7 +35,7 @@ function UsuariosAdmin() {
   };
 
   const cambiarEstado = (id, nuevoEstado) => {
-    axios.patch(`https://inmobiliaria-proyecto.onrender.com/api/usuarios/estado/${id}`, { activo: nuevoEstado }, { headers })
+    api.patch(`/usuarios/estado/${id}`, { activo: nuevoEstado })
       .then(() => {
         setSnackbar({ open: true, mensaje: 'Estado actualizado', tipo: 'success' });
         cargarUsuarios();

--- a/inmobiliaria-frontend/vite.config.js
+++ b/inmobiliaria-frontend/vite.config.js
@@ -5,10 +5,4 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: "/",
-  build: {
-    rollupOptions: {
-      // externalize missing peer dependency to avoid bundling errors
-      external: ['prop-types'],
-    },
-  },
 })


### PR DESCRIPTION
## Summary
- bundle `prop-types` with frontend build to prevent runtime import failures
- route admin user/message requests through configured axios instance
- auto-attach stored auth token and log out on expired sessions

## Testing
- `npm test` (frontend; fails: Missing script)
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689bbc007e048325bd2c55bfa860cf3b