### PR TITLE
feat: add responsive property filters and cards

### DIFF
--- a/inmobiliaria-frontend/src/components/FiltersBar.tsx
+++ b/inmobiliaria-frontend/src/components/FiltersBar.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import Toolbar from '@mui/material/Toolbar';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Slider from '@mui/material/Slider';
+import IconButton from '@mui/material/IconButton';
+import Popover from '@mui/material/Popover';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import TuneIcon from '@mui/icons-material/Tune';
+import PropTypes from 'prop-types';
+
+function FiltersBar({ filters, setFilter }: any) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleMore = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => setAnchorEl(null);
+
+  return (
+    <Box>
+      <Toolbar disableGutters sx={{ gap: 2, flexWrap: 'wrap' }}>
+        <TextField
+          size="small"
+          label="Ciudad"
+          value={filters.city}
+          onChange={e => setFilter('city', e.target.value)}
+        />
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel id="type-label">Tipo</InputLabel>
+          <Select
+            labelId="type-label"
+            label="Tipo"
+            value={filters.type}
+            onChange={e => setFilter('type', e.target.value)}
+          >
+            <MenuItem value="">Cualquiera</MenuItem>
+            <MenuItem value="Casa">Casa</MenuItem>
+            <MenuItem value="Departamento">Departamento</MenuItem>
+          </Select>
+        </FormControl>
+        <Box sx={{ width: 160, px: 1 }}>
+          <Slider
+            value={filters.price}
+            onChange={(_, val) => setFilter('price', val)}
+            valueLabelDisplay="auto"
+            min={0}
+            max={1000000}
+          />
+        </Box>
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel id="rooms-label">Ambientes</InputLabel>
+          <Select
+            labelId="rooms-label"
+            label="Ambientes"
+            value={filters.rooms}
+            onChange={e => setFilter('rooms', e.target.value)}
+          >
+            <MenuItem value="">Cualquiera</MenuItem>
+            {[1, 2, 3, 4].map(n => (
+              <MenuItem key={n} value={String(n)}>
+                {n}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <IconButton color="primary" onClick={handleMore} aria-label="más filtros">
+          <TuneIcon />
+        </IconButton>
+      </Toolbar>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Typography variant="subtitle2">Más filtros</Typography>
+          <TextField
+            size="small"
+            label="Barrio"
+            value={filters.neighborhood || ''}
+            onChange={e => setFilter('neighborhood', e.target.value)}
+          />
+        </Box>
+      </Popover>
+    </Box>
+  );
+}
+
+FiltersBar.propTypes = {
+  filters: PropTypes.object.isRequired,
+  setFilter: PropTypes.func.isRequired
+};
+
+export default FiltersBar;

--- a/inmobiliaria-frontend/src/components/MobileFiltersDrawer.tsx
+++ b/inmobiliaria-frontend/src/components/MobileFiltersDrawer.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Drawer from '@mui/material/Drawer';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Slider from '@mui/material/Slider';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import CloseIcon from '@mui/icons-material/Close';
+import PropTypes from 'prop-types';
+
+function MobileFiltersDrawer({ filters, setFilter, clearFilters }: any) {
+  const [open, setOpen] = useState(false);
+  const toggleDrawer = () => setOpen(prev => !prev);
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        startIcon={<FilterListIcon />}
+        onClick={toggleDrawer}
+        sx={{ position: 'sticky', top: 0, zIndex: 1200, m: 1 }}
+      >
+        Filtrar
+      </Button>
+      <Drawer anchor="bottom" open={open} onClose={toggleDrawer}>
+        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant="h6">Filtros</Typography>
+            <IconButton onClick={toggleDrawer}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+          <TextField
+            size="small"
+            label="Ciudad"
+            value={filters.city}
+            onChange={e => setFilter('city', e.target.value)}
+          />
+          <FormControl size="small">
+            <InputLabel id="m-type-label">Tipo</InputLabel>
+            <Select
+              labelId="m-type-label"
+              label="Tipo"
+              value={filters.type}
+              onChange={e => setFilter('type', e.target.value)}
+            >
+              <MenuItem value="">Cualquiera</MenuItem>
+              <MenuItem value="Casa">Casa</MenuItem>
+              <MenuItem value="Departamento">Departamento</MenuItem>
+            </Select>
+          </FormControl>
+          <Box sx={{ px: 1 }}>
+            <Slider
+              value={filters.price}
+              onChange={(_, val) => setFilter('price', val)}
+              valueLabelDisplay="auto"
+              min={0}
+              max={1000000}
+            />
+          </Box>
+          <FormControl size="small">
+            <InputLabel id="m-rooms-label">Ambientes</InputLabel>
+            <Select
+              labelId="m-rooms-label"
+              label="Ambientes"
+              value={filters.rooms}
+              onChange={e => setFilter('rooms', e.target.value)}
+            >
+              <MenuItem value="">Cualquiera</MenuItem>
+              {[1, 2, 3, 4].map(n => (
+                <MenuItem key={n} value={String(n)}>
+                  {n}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            size="small"
+            label="Barrio"
+            value={filters.neighborhood || ''}
+            onChange={e => setFilter('neighborhood', e.target.value)}
+          />
+          <Button onClick={clearFilters}>Limpiar filtros</Button>
+        </Box>
+      </Drawer>
+    </>
+  );
+}
+
+MobileFiltersDrawer.propTypes = {
+  filters: PropTypes.object.isRequired,
+  setFilter: PropTypes.func.isRequired,
+  clearFilters: PropTypes.func.isRequired
+};
+
+export default MobileFiltersDrawer;

--- a/inmobiliaria-frontend/src/components/PropertyCard.tsx
+++ b/inmobiliaria-frontend/src/components/PropertyCard.tsx
@@ -1,0 +1,68 @@
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardMedia from '@mui/material/CardMedia';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import PropTypes from 'prop-types';
+
+export interface Property {
+  id: number;
+  title: string;
+  city: string;
+  type: string;
+  price: number;
+  rooms: number;
+  date: string;
+  image: string;
+  neighborhood?: string;
+}
+
+function PropertyCard({ property }: { property: Property }) {
+  return (
+    <Card>
+      <Box sx={{ position: 'relative', pt: '56.25%' }}>
+        <CardMedia
+          component="img"
+          image={property.image}
+          alt={property.title}
+          loading="lazy"
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover'
+          }}
+        />
+      </Box>
+      <CardContent>
+        <Typography variant="subtitle1" gutterBottom>
+          {property.title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {property.city} - {property.type}
+        </Typography>
+        <Typography variant="h6" color="primary">
+          ${property.price.toLocaleString()}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+PropertyCard.propTypes = {
+  property: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    city: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    price: PropTypes.number.isRequired,
+    rooms: PropTypes.number.isRequired,
+    date: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    neighborhood: PropTypes.string
+  }).isRequired
+};
+
+export default PropertyCard;

--- a/inmobiliaria-frontend/src/hooks/usePropertyFilters.ts
+++ b/inmobiliaria-frontend/src/hooks/usePropertyFilters.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+
+export interface PropertyFilters {
+  city: string;
+  type: string;
+  price: [number, number];
+  rooms: string;
+  [key: string]: any;
+}
+
+const defaultFilters: PropertyFilters = {
+  city: '',
+  type: '',
+  price: [0, 1000000],
+  rooms: ''
+};
+
+export function usePropertyFilters() {
+  const [filters, setFilters] = useState<PropertyFilters>(defaultFilters);
+  const [debouncedFilters, setDebouncedFilters] = useState<PropertyFilters>(defaultFilters);
+
+  // Restore from URL on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const restored: PropertyFilters = {
+      city: params.get('city') || '',
+      type: params.get('type') || '',
+      price: [
+        params.get('minPrice') ? Number(params.get('minPrice')) : 0,
+        params.get('maxPrice') ? Number(params.get('maxPrice')) : 1000000
+      ],
+      rooms: params.get('rooms') || ''
+    };
+    const neighborhood = params.get('neighborhood');
+    if (neighborhood) restored.neighborhood = neighborhood;
+    setFilters(restored);
+    setDebouncedFilters(restored);
+  }, []);
+
+  // Debounce apply & sync with URL
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedFilters(filters);
+      const params = new URLSearchParams();
+      if (filters.city) params.set('city', filters.city);
+      if (filters.type) params.set('type', filters.type);
+      if (filters.price[0]) params.set('minPrice', String(filters.price[0]));
+      if (filters.price[1] !== 1000000) params.set('maxPrice', String(filters.price[1]));
+      if (filters.rooms) params.set('rooms', filters.rooms);
+      if (filters.neighborhood) params.set('neighborhood', filters.neighborhood);
+      const url = `${window.location.pathname}?${params.toString()}`;
+      window.history.replaceState({}, '', url);
+    }, 400);
+
+    return () => clearTimeout(handler);
+  }, [filters]);
+
+  const setFilter = (key: string, value: any) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
+  };
+
+  const clearFilters = () => {
+    setFilters(defaultFilters);
+  };
+
+  return { filters, debouncedFilters, setFilter, clearFilters };
+}
+
+export default usePropertyFilters;

--- a/inmobiliaria-frontend/src/pages/PropertiesPage.jsx
+++ b/inmobiliaria-frontend/src/pages/PropertiesPage.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+import Skeleton from '@mui/material/Skeleton';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import FiltersBar from '../components/FiltersBar';
+import MobileFiltersDrawer from '../components/MobileFiltersDrawer';
+import PropertyCard from '../components/PropertyCard';
+import usePropertyFilters from '../hooks/usePropertyFilters';
+
+const mockProperties = [
+  {
+    id: 1,
+    title: 'Casa céntrica',
+    city: 'Buenos Aires',
+    type: 'Casa',
+    price: 120000,
+    rooms: 3,
+    date: '2024-01-10',
+    image: 'https://placehold.co/600x337'
+  },
+  {
+    id: 2,
+    title: 'Departamento moderno',
+    city: 'Córdoba',
+    type: 'Departamento',
+    price: 90000,
+    rooms: 2,
+    date: '2024-02-15',
+    image: 'https://placehold.co/600x337'
+  },
+  {
+    id: 3,
+    title: 'Loft con vista',
+    city: 'Mendoza',
+    type: 'Departamento',
+    price: 150000,
+    rooms: 1,
+    date: '2024-03-05',
+    image: 'https://placehold.co/600x337'
+  }
+];
+
+export default function PropertiesPage() {
+  const { filters, debouncedFilters, setFilter, clearFilters } = usePropertyFilters();
+  const [sort, setSort] = useState('date');
+  const [loading, setLoading] = useState(true);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => setLoading(false), 800);
+    return () => clearTimeout(timer);
+  }, [debouncedFilters, sort]);
+
+  const filtered = useMemo(() => {
+    return mockProperties.filter(p => {
+      if (debouncedFilters.city && !p.city.toLowerCase().includes(debouncedFilters.city.toLowerCase())) return false;
+      if (debouncedFilters.type && p.type !== debouncedFilters.type) return false;
+      if (p.price < debouncedFilters.price[0] || p.price > debouncedFilters.price[1]) return false;
+      if (debouncedFilters.rooms && String(p.rooms) !== debouncedFilters.rooms) return false;
+      if (debouncedFilters.neighborhood && !p.neighborhood?.toLowerCase().includes(debouncedFilters.neighborhood.toLowerCase())) return false;
+      return true;
+    });
+  }, [debouncedFilters]);
+
+  const sorted = useMemo(() => {
+    const arr = [...filtered];
+    if (sort === 'price-asc') arr.sort((a, b) => a.price - b.price);
+    else if (sort === 'price-desc') arr.sort((a, b) => b.price - a.price);
+    else arr.sort((a, b) => new Date(b.date) - new Date(a.date));
+    return arr;
+  }, [filtered, sort]);
+
+  const activeChips = [];
+  if (filters.city) activeChips.push({ key: 'city', label: `Ciudad: ${filters.city}` });
+  if (filters.type) activeChips.push({ key: 'type', label: `Tipo: ${filters.type}` });
+  if (filters.price[0] || filters.price[1] !== 1000000)
+    activeChips.push({ key: 'price', label: `Precio: ${filters.price[0]} - ${filters.price[1]}` });
+  if (filters.rooms) activeChips.push({ key: 'rooms', label: `Ambientes: ${filters.rooms}` });
+  if (filters.neighborhood)
+    activeChips.push({ key: 'neighborhood', label: `Barrio: ${filters.neighborhood}` });
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {isMobile ? (
+        <MobileFiltersDrawer filters={filters} setFilter={setFilter} clearFilters={clearFilters} />
+      ) : (
+        <FiltersBar filters={filters} setFilter={setFilter} />
+      )}
+
+      <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        {activeChips.map(chip => (
+          <Chip
+            key={chip.key}
+            label={chip.label}
+            onDelete={() => setFilter(chip.key, chip.key === 'price' ? [0, 1000000] : '')}
+          />
+        ))}
+        {activeChips.length ? (
+          <Button onClick={clearFilters}>Limpiar filtros</Button>
+        ) : null}
+      </Box>
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', my: 2 }}>
+        <Select value={sort} onChange={e => setSort(e.target.value)} size="small">
+          <MenuItem value="date">Fecha</MenuItem>
+          <MenuItem value="price-asc">Precio ↑</MenuItem>
+          <MenuItem value="price-desc">Precio ↓</MenuItem>
+        </Select>
+      </Box>
+
+      {loading ? (
+        <Grid container spacing={2}>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={i}>
+              <Skeleton variant="rectangular" height={180} />
+            </Grid>
+          ))}
+        </Grid>
+      ) : sorted.length ? (
+        <Grid container spacing={2}>
+          {sorted.map(property => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={property.id}>
+              <PropertyCard property={property} />
+            </Grid>
+          ))}
+        </Grid>
+      ) : (
+        <Box sx={{ textAlign: 'center', py: 5 }}>
+          <Typography>No hay resultados.</Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add `usePropertyFilters` hook with debounce and URL sync
- implement desktop `FiltersBar`, mobile drawer and `PropertyCard`
- provide `PropertiesPage` example with active chips, skeletons and sorting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bcdeb987c8325af9fba6c050c63f5