### PR TITLE
feat: desktop filter bar

### DIFF
--- a/inmobiliaria-frontend/src/components/FiltersBar.tsx
+++ b/inmobiliaria-frontend/src/components/FiltersBar.tsx
@@ -5,24 +5,22 @@ import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import Slider from '@mui/material/Slider';
-import IconButton from '@mui/material/IconButton';
-import Popover from '@mui/material/Popover';
+import Button from '@mui/material/Button';
+import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import TuneIcon from '@mui/icons-material/Tune';
+import IconButton from '@mui/material/IconButton';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import CloseIcon from '@mui/icons-material/Close';
 import PropTypes from 'prop-types';
+import FiltersForm from './FiltersForm';
 
-function FiltersBar({ filters, setFilter }: any) {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-  const handleMore = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => setAnchorEl(null);
+function FiltersBar({ filters, setFilter, sort, setSort, clearFilters }: any) {
+  const [open, setOpen] = useState(false);
+  const toggleDrawer = () => setOpen(prev => !prev);
 
   return (
-    <Box>
+    <>
       <Toolbar disableGutters sx={{ gap: 2, flexWrap: 'wrap' }}>
         <TextField
           size="small"
@@ -43,58 +41,52 @@ function FiltersBar({ filters, setFilter }: any) {
             <MenuItem value="Departamento">Departamento</MenuItem>
           </Select>
         </FormControl>
-        <Box sx={{ width: 160, px: 1 }}>
-          <Slider
-            value={filters.price}
-            onChange={(_, val) => setFilter('price', val)}
-            valueLabelDisplay="auto"
-            min={0}
-            max={1000000}
-          />
-        </Box>
-        <FormControl size="small" sx={{ minWidth: 120 }}>
-          <InputLabel id="rooms-label">Ambientes</InputLabel>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="sort-label">Ordenar</InputLabel>
           <Select
-            labelId="rooms-label"
-            label="Ambientes"
-            value={filters.rooms}
-            onChange={e => setFilter('rooms', e.target.value)}
+            labelId="sort-label"
+            label="Ordenar"
+            value={sort}
+            onChange={e => setSort(e.target.value)}
           >
-            <MenuItem value="">Cualquiera</MenuItem>
-            {[1, 2, 3, 4].map(n => (
-              <MenuItem key={n} value={String(n)}>
-                {n}
-              </MenuItem>
-            ))}
+            <MenuItem value="date">Fecha</MenuItem>
+            <MenuItem value="price-asc">Precio ↑</MenuItem>
+            <MenuItem value="price-desc">Precio ↓</MenuItem>
           </Select>
         </FormControl>
-        <IconButton color="primary" onClick={handleMore} aria-label="más filtros">
-          <TuneIcon />
-        </IconButton>
+        <Button startIcon={<FilterListIcon />} onClick={toggleDrawer} variant="outlined">
+          Más filtros
+        </Button>
       </Toolbar>
-      <Popover
-        open={Boolean(anchorEl)}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <Typography variant="subtitle2">Más filtros</Typography>
-          <TextField
-            size="small"
-            label="Barrio"
-            value={filters.neighborhood || ''}
-            onChange={e => setFilter('neighborhood', e.target.value)}
-          />
+      <Drawer anchor="right" open={open} onClose={toggleDrawer} PaperProps={{ sx: { width: 340 } }}>
+        <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant="h6">Filtros</Typography>
+            <IconButton onClick={toggleDrawer}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+          <Box sx={{ p: 2, pt: 0, overflow: 'auto', flex: 1 }}>
+            <FiltersForm filters={filters} setFilter={setFilter} />
+          </Box>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, p: 2, borderTop: 1, borderColor: 'divider' }}>
+            <Button onClick={clearFilters}>Limpiar</Button>
+            <Button variant="contained" onClick={toggleDrawer}>
+              Aplicar
+            </Button>
+          </Box>
         </Box>
-      </Popover>
-    </Box>
+      </Drawer>
+    </>
   );
 }
 
 FiltersBar.propTypes = {
   filters: PropTypes.object.isRequired,
-  setFilter: PropTypes.func.isRequired
+  setFilter: PropTypes.func.isRequired,
+  sort: PropTypes.string.isRequired,
+  setSort: PropTypes.func.isRequired,
+  clearFilters: PropTypes.func.isRequired
 };
 
 export default FiltersBar;

--- a/inmobiliaria-frontend/src/components/FiltersForm.tsx
+++ b/inmobiliaria-frontend/src/components/FiltersForm.tsx
@@ -1,0 +1,106 @@
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Slider from '@mui/material/Slider';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import PropTypes from 'prop-types';
+
+function FiltersForm({ filters, setFilter }: any) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography>Ubicación</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            size="small"
+            label="Ciudad"
+            value={filters.city}
+            onChange={e => setFilter('city', e.target.value)}
+          />
+          <TextField
+            size="small"
+            label="Barrio"
+            value={filters.neighborhood || ''}
+            onChange={e => setFilter('neighborhood', e.target.value)}
+          />
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography>Tipo de propiedad</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <FormControl size="small" fullWidth>
+            <InputLabel id="m-type-label">Tipo</InputLabel>
+            <Select
+              labelId="m-type-label"
+              label="Tipo"
+              value={filters.type}
+              onChange={e => setFilter('type', e.target.value)}
+            >
+              <MenuItem value="">Cualquiera</MenuItem>
+              <MenuItem value="Casa">Casa</MenuItem>
+              <MenuItem value="Departamento">Departamento</MenuItem>
+            </Select>
+          </FormControl>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography>Precio</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ px: 1 }}>
+          <Slider
+            value={filters.price}
+            onChange={(_, val) => setFilter('price', val)}
+            valueLabelDisplay="auto"
+            min={0}
+            max={1000000}
+          />
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography>Ambientes</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <FormControl size="small" fullWidth>
+            <InputLabel id="m-rooms-label">Ambientes</InputLabel>
+            <Select
+              labelId="m-rooms-label"
+              label="Ambientes"
+              value={filters.rooms}
+              onChange={e => setFilter('rooms', e.target.value)}
+            >
+              <MenuItem value="">Cualquiera</MenuItem>
+              {[1, 2, 3, 4].map(n => (
+                <MenuItem key={n} value={String(n)}>
+                  {n}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+}
+
+FiltersForm.propTypes = {
+  filters: PropTypes.object.isRequired,
+  setFilter: PropTypes.func.isRequired
+};
+
+export default FiltersForm;

--- a/inmobiliaria-frontend/src/components/MobileFiltersDrawer.tsx
+++ b/inmobiliaria-frontend/src/components/MobileFiltersDrawer.tsx
@@ -1,18 +1,13 @@
 import { useState } from 'react';
 import Button from '@mui/material/Button';
 import Drawer from '@mui/material/Drawer';
-import TextField from '@mui/material/TextField';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import Select from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
-import Slider from '@mui/material/Slider';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import CloseIcon from '@mui/icons-material/Close';
 import PropTypes from 'prop-types';
+import FiltersForm from './FiltersForm';
 
 function MobileFiltersDrawer({ filters, setFilter, clearFilters }: any) {
   const [open, setOpen] = useState(false);
@@ -41,65 +36,28 @@ function MobileFiltersDrawer({ filters, setFilter, clearFilters }: any) {
           Filtrar
         </Button>
       </Box>
-      <Drawer anchor="bottom" open={open} onClose={toggleDrawer}>
-        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={toggleDrawer}
+        PaperProps={{ sx: { borderTopLeftRadius: 8, borderTopRightRadius: 8, maxHeight: '80vh' } }}
+      >
+        <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <Typography variant="h6">Filtros</Typography>
             <IconButton onClick={toggleDrawer}>
               <CloseIcon />
             </IconButton>
           </Box>
-          <TextField
-            size="small"
-            label="Ciudad"
-            value={filters.city}
-            onChange={e => setFilter('city', e.target.value)}
-          />
-          <FormControl size="small">
-            <InputLabel id="m-type-label">Tipo</InputLabel>
-            <Select
-              labelId="m-type-label"
-              label="Tipo"
-              value={filters.type}
-              onChange={e => setFilter('type', e.target.value)}
-            >
-              <MenuItem value="">Cualquiera</MenuItem>
-              <MenuItem value="Casa">Casa</MenuItem>
-              <MenuItem value="Departamento">Departamento</MenuItem>
-            </Select>
-          </FormControl>
-          <Box sx={{ px: 1 }}>
-            <Slider
-              value={filters.price}
-              onChange={(_, val) => setFilter('price', val)}
-              valueLabelDisplay="auto"
-              min={0}
-              max={1000000}
-            />
+          <Box sx={{ p: 2, pt: 0, overflow: 'auto', flex: 1 }}>
+            <FiltersForm filters={filters} setFilter={setFilter} />
           </Box>
-          <FormControl size="small">
-            <InputLabel id="m-rooms-label">Ambientes</InputLabel>
-            <Select
-              labelId="m-rooms-label"
-              label="Ambientes"
-              value={filters.rooms}
-              onChange={e => setFilter('rooms', e.target.value)}
-            >
-              <MenuItem value="">Cualquiera</MenuItem>
-              {[1, 2, 3, 4].map(n => (
-                <MenuItem key={n} value={String(n)}>
-                  {n}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <TextField
-            size="small"
-            label="Barrio"
-            value={filters.neighborhood || ''}
-            onChange={e => setFilter('neighborhood', e.target.value)}
-          />
-          <Button onClick={clearFilters}>Limpiar filtros</Button>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, p: 2, borderTop: 1, borderColor: 'divider' }}>
+            <Button onClick={clearFilters}>Limpiar</Button>
+            <Button variant="contained" onClick={toggleDrawer}>
+              Aplicar
+            </Button>
+          </Box>
         </Box>
       </Drawer>
     </>

--- a/inmobiliaria-frontend/src/pages/PropertiesPage.jsx
+++ b/inmobiliaria-frontend/src/pages/PropertiesPage.jsx
@@ -92,9 +92,24 @@ export default function PropertiesPage() {
   return (
     <Box sx={{ p: 2 }}>
       {isMobile ? (
-        <MobileFiltersDrawer filters={filters} setFilter={setFilter} clearFilters={clearFilters} />
+        <>
+          <MobileFiltersDrawer filters={filters} setFilter={setFilter} clearFilters={clearFilters} />
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', my: 2 }}>
+            <Select value={sort} onChange={e => setSort(e.target.value)} size="small">
+              <MenuItem value="date">Fecha</MenuItem>
+              <MenuItem value="price-asc">Precio ↑</MenuItem>
+              <MenuItem value="price-desc">Precio ↓</MenuItem>
+            </Select>
+          </Box>
+        </>
       ) : (
-        <FiltersBar filters={filters} setFilter={setFilter} />
+        <FiltersBar
+          filters={filters}
+          setFilter={setFilter}
+          sort={sort}
+          setSort={setSort}
+          clearFilters={clearFilters}
+        />
       )}
 
       <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
@@ -108,14 +123,6 @@ export default function PropertiesPage() {
         {activeChips.length ? (
           <Button onClick={clearFilters}>Limpiar filtros</Button>
         ) : null}
-      </Box>
-
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', my: 2 }}>
-        <Select value={sort} onChange={e => setSort(e.target.value)} size="small">
-          <MenuItem value="date">Fecha</MenuItem>
-          <MenuItem value="price-asc">Precio ↑</MenuItem>
-          <MenuItem value="price-desc">Precio ↓</MenuItem>
-        </Select>
       </Box>
 
       {loading ? (


### PR DESCRIPTION
## Summary
- add reusable FiltersForm component for shared accordion filter sections
- redesign desktop filter bar with quick fields and right-side drawer
- sync mobile drawer with sticky footer and shared content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bdad212208325a01f75db1a0278ef