### PR TITLE
feat: add property favorites for clients

### DIFF
--- a/inmobiliaria-backend/controllers/favorito.controller.js
+++ b/inmobiliaria-backend/controllers/favorito.controller.js
@@ -1,0 +1,52 @@
+// Importa el modelo de favoritos
+const Favorito = require('../models/favorito.model');
+
+// GET /api/favoritos
+// Obtiene todas las propiedades favoritas del usuario logueado
+const obtenerFavoritos = (req, res) => {
+  const usuarioId = req.usuario.id;
+
+  Favorito.obtenerFavoritosPorUsuario(usuarioId, (err, resultados) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Error al obtener favoritos' });
+    }
+    res.json(resultados.rows);
+  });
+};
+
+// POST /api/favoritos/:propiedadId
+// Agrega una propiedad a los favoritos del usuario
+const agregarFavorito = (req, res) => {
+  const usuarioId = req.usuario.id;
+  const propiedadId = req.params.propiedadId;
+
+  Favorito.agregarFavorito(usuarioId, propiedadId, (err) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Error al guardar favorito' });
+    }
+    res.status(201).json({ mensaje: 'Favorito agregado' });
+  });
+};
+
+// DELETE /api/favoritos/:propiedadId
+// Elimina una propiedad de los favoritos del usuario
+const eliminarFavorito = (req, res) => {
+  const usuarioId = req.usuario.id;
+  const propiedadId = req.params.propiedadId;
+
+  Favorito.eliminarFavorito(usuarioId, propiedadId, (err) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Error al eliminar favorito' });
+    }
+    res.json({ mensaje: 'Favorito eliminado' });
+  });
+};
+
+module.exports = {
+  obtenerFavoritos,
+  agregarFavorito,
+  eliminarFavorito,
+};

--- a/inmobiliaria-backend/index.js
+++ b/inmobiliaria-backend/index.js
@@ -12,7 +12,7 @@ const propiedadRoutes = require('./routes/propiedad.routes');
 const usuarioRoutes = require('./routes/usuario.routes');
 const mensajeRoutes = require('./routes/mensaje.routes');
 const healthRoutes = require('./routes/health.routes');
-
+const favoritoRoutes = require('./routes/favorito.routes');
 
 // Middlewares
 app.use(cors()); // Permite peticiones de distintos orígenes (frontend-backend)
@@ -23,6 +23,7 @@ app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/propiedades', propiedadRoutes);
 app.use('/api/mensajes', mensajeRoutes);
 app.use('/api/health', healthRoutes);
+app.use('/api/favoritos', favoritoRoutes);
 
 // Iniciamos el servidor
 app.listen(PORT, () => {

--- a/inmobiliaria-backend/middlewares/soloCliente.middleware.js
+++ b/inmobiliaria-backend/middlewares/soloCliente.middleware.js
@@ -1,0 +1,8 @@
+const soloCliente = (req, res, next) => {
+  if (!req.usuario || req.usuario.rol !== 'cliente') {
+    return res.status(403).json({ error: 'Solo clientes' });
+  }
+  next();
+};
+
+module.exports = soloCliente;

--- a/inmobiliaria-backend/models/favorito.model.js
+++ b/inmobiliaria-backend/models/favorito.model.js
@@ -1,0 +1,30 @@
+// Importamos la conexión a la base de datos
+const db = require('../config/db');
+
+// Agrega una propiedad a favoritos
+const agregarFavorito = (usuarioId, propiedadId, callback) => {
+  const sql = 'INSERT INTO favoritos (usuario_id, propiedad_id) VALUES ($1, $2)';
+  db.query(sql, [usuarioId, propiedadId], callback);
+};
+
+// Elimina una propiedad de favoritos
+const eliminarFavorito = (usuarioId, propiedadId, callback) => {
+  const sql = 'DELETE FROM favoritos WHERE usuario_id = $1 AND propiedad_id = $2';
+  db.query(sql, [usuarioId, propiedadId], callback);
+};
+
+// Obtiene todas las propiedades favoritas de un usuario
+const obtenerFavoritosPorUsuario = (usuarioId, callback) => {
+  const sql = `
+    SELECT p.* FROM favoritos f
+    JOIN propiedades p ON p.id = f.propiedad_id
+    WHERE f.usuario_id = $1
+  `;
+  db.query(sql, [usuarioId], callback);
+};
+
+module.exports = {
+  agregarFavorito,
+  eliminarFavorito,
+  obtenerFavoritosPorUsuario,
+};

--- a/inmobiliaria-backend/routes/favorito.routes.js
+++ b/inmobiliaria-backend/routes/favorito.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const controlador = require('../controllers/favorito.controller');
+const verifyToken = require('../middlewares/auth.middleware');
+const soloCliente = require('../middlewares/soloCliente.middleware');
+
+// Rutas protegidas para gestionar favoritos
+router.get('/', verifyToken, soloCliente, controlador.obtenerFavoritos);
+router.post('/:propiedadId', verifyToken, soloCliente, controlador.agregarFavorito);
+router.delete('/:propiedadId', verifyToken, soloCliente, controlador.eliminarFavorito);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- allow authenticated clients to save and remove property favorites
- add backend endpoints and middleware for managing favorites
- add favorites button with client role checks on property detail page

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6410c4208325a6198f3a6c029b21