### PR TITLE
Add favorites page and navbar link

### DIFF
--- a/inmobiliaria-backend/controllers/favorito.controller.js
+++ b/inmobiliaria-backend/controllers/favorito.controller.js
@@ -1,0 +1,52 @@
+// Importa el modelo de favoritos
+const Favorito = require('../models/favorito.model');
+
+// GET /api/favoritos
+// Obtiene todas las propiedades favoritas del usuario logueado
+const obtenerFavoritos = (req, res) => {
+  const usuarioId = req.usuario.id;
+
+  Favorito.obtenerFavoritosPorUsuario(usuarioId, (err, resultados) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Error al obtener favoritos' });
+    }
+    res.json(resultados.rows);
+  });
+};
+
+// POST /api/favoritos/:propiedadId
+// Agrega una propiedad a los favoritos del usuario
+const agregarFavorito = (req, res) => {
+  const usuarioId = req.usuario.id;
+  const propiedadId = req.params.propiedadId;
+
+  Favorito.agregarFavorito(usuarioId, propiedadId, (err) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Error al guardar favorito' });
+    }
+    res.status(201).json({ mensaje: 'Favorito agregado' });
+  });
+};
+
+// DELETE /api/favoritos/:propiedadId
+// Elimina una propiedad de los favoritos del usuario
+const eliminarFavorito = (req, res) => {
+  const usuarioId = req.usuario.id;
+  const propiedadId = req.params.propiedadId;
+
+  Favorito.eliminarFavorito(usuarioId, propiedadId, (err) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Error al eliminar favorito' });
+    }
+    res.json({ mensaje: 'Favorito eliminado' });
+  });
+};
+
+module.exports = {
+  obtenerFavoritos,
+  agregarFavorito,
+  eliminarFavorito,
+};

--- a/inmobiliaria-backend/index.js
+++ b/inmobiliaria-backend/index.js
@@ -12,7 +12,7 @@ const propiedadRoutes = require('./routes/propiedad.routes');
 const usuarioRoutes = require('./routes/usuario.routes');
 const mensajeRoutes = require('./routes/mensaje.routes');
 const healthRoutes = require('./routes/health.routes');
-
+const favoritoRoutes = require('./routes/favorito.routes');
 
 // Middlewares
 app.use(cors()); // Permite peticiones de distintos orígenes (frontend-backend)
@@ -23,6 +23,7 @@ app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/propiedades', propiedadRoutes);
 app.use('/api/mensajes', mensajeRoutes);
 app.use('/api/health', healthRoutes);
+app.use('/api/favoritos', favoritoRoutes);
 
 // Iniciamos el servidor
 app.listen(PORT, () => {

--- a/inmobiliaria-backend/middlewares/soloCliente.middleware.js
+++ b/inmobiliaria-backend/middlewares/soloCliente.middleware.js
@@ -1,0 +1,9 @@
+const soloCliente = (req, res, next) => {
+  const rol = req.usuario?.rol;
+  if (!rol || (rol !== 'cliente' && rol !== 'usuario')) {
+    return res.status(403).json({ error: 'Solo clientes' });
+  }
+  next();
+};
+
+module.exports = soloCliente;

--- a/inmobiliaria-backend/models/favorito.model.js
+++ b/inmobiliaria-backend/models/favorito.model.js
@@ -1,0 +1,30 @@
+// Importamos la conexión a la base de datos
+const db = require('../config/db');
+
+// Agrega una propiedad a favoritos
+const agregarFavorito = (usuarioId, propiedadId, callback) => {
+  const sql = 'INSERT INTO favoritos (usuario_id, propiedad_id) VALUES ($1, $2)';
+  db.query(sql, [usuarioId, propiedadId], callback);
+};
+
+// Elimina una propiedad de favoritos
+const eliminarFavorito = (usuarioId, propiedadId, callback) => {
+  const sql = 'DELETE FROM favoritos WHERE usuario_id = $1 AND propiedad_id = $2';
+  db.query(sql, [usuarioId, propiedadId], callback);
+};
+
+// Obtiene todas las propiedades favoritas de un usuario
+const obtenerFavoritosPorUsuario = (usuarioId, callback) => {
+  const sql = `
+    SELECT p.* FROM favoritos f
+    JOIN propiedades p ON p.id = f.propiedad_id
+    WHERE f.usuario_id = $1
+  `;
+  db.query(sql, [usuarioId], callback);
+};
+
+module.exports = {
+  agregarFavorito,
+  eliminarFavorito,
+  obtenerFavoritosPorUsuario,
+};

--- a/inmobiliaria-backend/routes/favorito.routes.js
+++ b/inmobiliaria-backend/routes/favorito.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const controlador = require('../controllers/favorito.controller');
+const verifyToken = require('../middlewares/auth.middleware');
+const soloCliente = require('../middlewares/soloCliente.middleware');
+
+// Rutas protegidas para gestionar favoritos
+router.get('/', verifyToken, soloCliente, controlador.obtenerFavoritos);
+router.post('/:propiedadId', verifyToken, soloCliente, controlador.agregarFavorito);
+router.delete('/:propiedadId', verifyToken, soloCliente, controlador.eliminarFavorito);
+
+module.exports = router;

--- a/inmobiliaria-frontend/src/App.jsx
+++ b/inmobiliaria-frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import DetallePropiedad from './pages/DetallePropiedad';
+import Favoritos from './pages/Favoritos';
 import AdminPanel from './pages/AdminPanel';
 import Contacto from './pages/Contacto';
 import NotFound from './pages/NotFound';
@@ -44,6 +45,8 @@ function App({ setModo, modo }) {
           <Route path="/propiedad/:id" element={<DetallePropiedad />} />
           {/* Página de contacto */}
           <Route path="/contacto" element={<Contacto />} />
+          {/* Favoritos del usuario */}
+          <Route path="/favoritos" element={<Favoritos />} />
           {/* Rutas protegidas solo para administradores */}
           <Route path="/admin" element={<RutaPrivadaAdmin><AdminPanel /></RutaPrivadaAdmin>} />
           <Route path="/admin/usuarios" element={<RutaPrivadaAdmin><UsuariosAdmin /></RutaPrivadaAdmin>} />

--- a/inmobiliaria-frontend/src/components/Navbar.jsx
+++ b/inmobiliaria-frontend/src/components/Navbar.jsx
@@ -17,6 +17,7 @@ function Navbar({ setModo, modo }) {
   const navigate = useNavigate();
   const usuario = JSON.parse(localStorage.getItem("usuario"));
   const token = localStorage.getItem("token");
+  const puedeFavoritos = ["cliente", "usuario"].includes(usuario?.rol);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -103,6 +104,15 @@ function Navbar({ setModo, modo }) {
                   </MenuItem>
                 </>
               )}
+              {puedeFavoritos && (
+                <MenuItem
+                  component={Link}
+                  to="/favoritos"
+                  onClick={handleMenuClose}
+                >
+                  Favoritos
+                </MenuItem>
+              )}
               {token && (
                 <MenuItem
                   onClick={() => {
@@ -147,6 +157,12 @@ function Navbar({ setModo, modo }) {
                   Mensajes
                 </AppButton>
               </>
+            )}
+
+            {puedeFavoritos && (
+              <AppButton variant="text" color="inherit" component={Link} to="/favoritos">
+                Favoritos
+              </AppButton>
             )}
 
             {token && (

--- a/inmobiliaria-frontend/src/pages/DetallePropiedad.jsx
+++ b/inmobiliaria-frontend/src/pages/DetallePropiedad.jsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import api from "../config/axios";
 import {
   Box,
   Typography,
@@ -17,6 +18,10 @@ function DetallePropiedad() {
   const { id } = useParams();
   const [propiedad, setPropiedad] = useState(null);
   const [error, setError] = useState("");
+  const [esFavorito, setEsFavorito] = useState(false);
+  const [mensaje, setMensaje] = useState("");
+  const usuario = JSON.parse(localStorage.getItem("usuario"));
+  const puedeFavoritos = ["cliente", "usuario"].includes(usuario?.rol);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -28,6 +33,40 @@ function DetallePropiedad() {
         setError("No se pudo cargar la propiedad.");
       });
   }, [id]);
+
+  useEffect(() => {
+    if (puedeFavoritos) {
+      api
+        .get("/favoritos")
+        .then((res) =>
+          setEsFavorito(res.data.some((f) => f.id === parseInt(id)))
+        )
+        .catch((err) => console.error(err));
+    }
+  }, [puedeFavoritos, id]);
+
+  const toggleFavorito = () => {
+    if (!usuario) {
+      navigate("/login");
+      return;
+    }
+    if (!puedeFavoritos) {
+      setMensaje("Solo clientes");
+      return;
+    }
+    const endpoint = `/favoritos/${id}`;
+    if (esFavorito) {
+      api
+        .delete(endpoint)
+        .then(() => setEsFavorito(false))
+        .catch(() => setMensaje("Error al eliminar favorito"));
+    } else {
+      api
+        .post(endpoint)
+        .then(() => setEsFavorito(true))
+        .catch(() => setMensaje("Error al agregar favorito"));
+    }
+  };
 
   if (error) return <Alert severity="error" sx={{ mt: 4 }}>{error}</Alert>;
 
@@ -62,7 +101,7 @@ function DetallePropiedad() {
             <strong>Precio:</strong> ${propiedad.precio}
           </Typography>
           <Typography>
-            <strong>Dirección:</strong> {propiedad.direccion}, {propiedad.ciudad},{" "}
+            <strong>Dirección:</strong> {propiedad.direccion}, {propiedad.ciudad}{" "}
             {propiedad.provincia}
           </Typography>
           <Typography>
@@ -82,7 +121,7 @@ function DetallePropiedad() {
             {new Date(propiedad.fecha_publicacion).toLocaleDateString()}
           </Typography>
 
-          <Box sx={{ mt: 3 }}>
+          <Box sx={{ mt: 3, display: "flex", gap: 2 }}>
             <Button
               variant="contained"
               color="primary"
@@ -97,7 +136,19 @@ function DetallePropiedad() {
             >
               Contactar por esta propiedad
             </Button>
+            <Button
+              variant="outlined"
+              color="secondary"
+              onClick={toggleFavorito}
+            >
+              {esFavorito ? "Quitar de Favoritos" : "Agregar a Favoritos"}
+            </Button>
           </Box>
+          {mensaje && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              {mensaje}
+            </Alert>
+          )}
         </CardContent>
       </Card>
     </Box>
@@ -105,5 +156,3 @@ function DetallePropiedad() {
 }
 
 export default DetallePropiedad;
-
-

--- a/inmobiliaria-frontend/src/pages/Favoritos.jsx
+++ b/inmobiliaria-frontend/src/pages/Favoritos.jsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { Box, Typography, Grid, Card, CardMedia, CardContent, CardActions, Button, IconButton, Alert } from '@mui/material';
+import Favorite from '@mui/icons-material/Favorite';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import api from '../config/axios';
+
+function Favoritos() {
+  const [propiedades, setPropiedades] = useState([]);
+  const [mensaje, setMensaje] = useState('');
+  const usuario = JSON.parse(localStorage.getItem('usuario'));
+  const puedeFavoritos = ['cliente', 'usuario'].includes(usuario?.rol);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!usuario) {
+      navigate('/login');
+      return;
+    }
+    if (!puedeFavoritos) {
+      setMensaje('Solo clientes');
+      return;
+    }
+    api
+      .get('/favoritos')
+      .then(res => setPropiedades(res.data))
+      .catch(() => setMensaje('Error al cargar favoritos'));
+  }, [usuario, puedeFavoritos, navigate]);
+
+  const eliminarFavorito = (id) => {
+    api
+      .delete(`/favoritos/${id}`)
+      .then(() => setPropiedades(propiedades.filter(p => p.id !== id)))
+      .catch(() => setMensaje('Error al eliminar favorito'));
+  };
+
+  if (mensaje && propiedades.length === 0) {
+    return (
+      <Box sx={{ mt: 4 }}>
+        <Alert severity="info">{mensaje}</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 4, px: { xs: 2, sm: 4 } }}>
+      <Typography variant="h4" component="h1" textAlign="center" gutterBottom>
+        Mis Favoritos
+      </Typography>
+
+      {mensaje && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {mensaje}
+        </Alert>
+      )}
+
+      {Array.isArray(propiedades) && propiedades.length > 0 ? (
+        <Grid container spacing={4} justifyContent="center" alignItems="stretch">
+          {propiedades.map((prop) => (
+            <Grid item key={prop.id} xs={12} sm={6} md={4} sx={{ display: 'flex' }}>
+              <Card
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  flexGrow: 1,
+                  borderRadius: 2,
+                  boxShadow: 3,
+                }}
+              >
+                <CardMedia
+                  component="img"
+                  height="200"
+                  image={prop.imagen_destacada}
+                  alt={prop.titulo}
+                  sx={{ objectFit: 'cover' }}
+                />
+                <CardContent sx={{ flexGrow: 1 }}>
+                  <Typography variant="h6" gutterBottom>
+                    {prop.titulo}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    paragraph
+                    sx={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      display: '-webkit-box',
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: 'vertical',
+                    }}
+                  >
+                    {prop.descripcion}
+                  </Typography>
+                  <Typography variant="body1">
+                    <strong>Precio:</strong> ${prop.precio}
+                  </Typography>
+                  <Typography variant="body1">
+                    <strong>Ciudad:</strong> {prop.ciudad}
+                  </Typography>
+                </CardContent>
+                <CardActions sx={{ justifyContent: 'space-between' }}>
+                  <IconButton onClick={() => eliminarFavorito(prop.id)} color="error">
+                    <Favorite />
+                  </IconButton>
+                  <Button
+                    component={RouterLink}
+                    to={`/propiedad/${prop.id}`}
+                    size="small"
+                    variant="outlined"
+                  >
+                    Ver más
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      ) : (
+        <Typography textAlign="center">
+          No tienes propiedades favoritas.
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+export default Favoritos;


### PR DESCRIPTION
## Summary
- add dedicated favorites page listing user's saved properties with remove option
- register favorites route and expose it through navbar link for authorized users

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6410c4208325a6198f3a6c029b21