### PR TITLE
Center filters and keep them visible on scroll

### DIFF
--- a/inmobiliaria-frontend/src/pages/Home.jsx
+++ b/inmobiliaria-frontend/src/pages/Home.jsx
@@ -100,7 +100,16 @@ function Home() {
       }}
     >
       {/* Columna izquierda: filtros */}
-      <Box sx={{ display: { xs: 'none', md: 'block' }, alignSelf: 'start' }}>
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          flexDirection: 'column',
+          alignItems: 'center',
+          position: 'sticky',
+          top: 16,
+          alignSelf: 'start',
+        }}
+      >
         <FiltersForm filters={filters} setFilter={setFilter} />
         <Button onClick={clearFilters} sx={{ mt: 2 }}>
           Limpiar


### PR DESCRIPTION
## Summary
- Center the desktop filters panel and make it sticky so it stays visible while scrolling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e995941dc8325ac563ddb44bbbbd1