### PR TITLE
Center filters vertically and widen panel

### DIFF
--- a/inmobiliaria-frontend/src/pages/Home.jsx
+++ b/inmobiliaria-frontend/src/pages/Home.jsx
@@ -93,14 +93,22 @@ function Home() {
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: { xs: '1fr', md: '260px 1fr 200px' },
+        gridTemplateColumns: { xs: '1fr', md: '320px 1fr' },
         gap: 2,
         px: { xs: 2, sm: 4 },
         mt: 2,
       }}
     >
       {/* Columna izquierda: filtros */}
-      <Box sx={{ display: { xs: 'none', md: 'block' }, alignSelf: 'start' }}>
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          flexDirection: 'column',
+          alignItems: 'center',
+          mt: { md: '20vh' },
+          width: '100%',
+        }}
+      >
         <FiltersForm filters={filters} setFilter={setFilter} />
         <Button onClick={clearFilters} sx={{ mt: 2 }}>
           Limpiar


### PR DESCRIPTION
## Summary
- Increase desktop filter column width so filter labels remain readable
- Start desktop filters lower on the page so they appear vertically centered and scroll with content

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e995941dc8325ac563ddb44bbbbd1