### PR TITLE
Enhance filter panel styling and layout

### DIFF
--- a/inmobiliaria-frontend/src/pages/Home.jsx
+++ b/inmobiliaria-frontend/src/pages/Home.jsx
@@ -11,7 +11,8 @@ import {
   Grid,
   useMediaQuery,
   IconButton,
-  Alert
+  Alert,
+  Paper,
 } from '@mui/material';
 import Favorite from '@mui/icons-material/Favorite';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
@@ -93,18 +94,30 @@ function Home() {
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: { xs: '1fr', md: '260px 1fr 200px' },
+        gridTemplateColumns: { xs: '1fr', md: '360px 1fr 240px' },
         gap: 2,
         px: { xs: 2, sm: 4 },
         mt: 2,
       }}
     >
       {/* Columna izquierda: filtros */}
-      <Box sx={{ display: { xs: 'none', md: 'block' }, alignSelf: 'start' }}>
-        <FiltersForm filters={filters} setFilter={setFilter} />
-        <Button onClick={clearFilters} sx={{ mt: 2 }}>
-          Limpiar
-        </Button>
+      <Box sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: 'center' }}>
+        <Paper
+          elevation={4}
+          sx={{
+            position: 'sticky',
+            top: '20vh',
+            p: 3,
+            width: '100%',
+            maxWidth: 320,
+            borderRadius: 2,
+          }}
+        >
+          <FiltersForm filters={filters} setFilter={setFilter} />
+          <Button fullWidth onClick={clearFilters} sx={{ mt: 2 }}>
+            Limpiar
+          </Button>
+        </Paper>
       </Box>
 
       {/* Columna central: listado de propiedades */}


### PR DESCRIPTION
## Summary
- Center filter panel within left column using sticky Paper card and 20vh offset for consistent visibility
- Broaden layout columns for a more spacious three-column design

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e995941dc8325ac563ddb44bbbbd1