### PR TITLE
fix: prevent filter panel from stretching

### DIFF
--- a/inmobiliaria-frontend/src/pages/Home.jsx
+++ b/inmobiliaria-frontend/src/pages/Home.jsx
@@ -100,7 +100,13 @@ function Home() {
       }}
     >
       {/* Columna izquierda: filtros */}
-      <Box sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: 'center' }}>
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          justifyContent: 'center',
+          alignItems: 'flex-start',
+        }}
+      >
         <Paper
           elevation={4}
           sx={{


### PR DESCRIPTION
## Summary
- prevent filter panel from stretching alongside property list by aligning filters to the top

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2e542e4508325acba8e26286f4aa0