### PR TITLE
Prevent footer from covering property cards

### DIFF
--- a/inmobiliaria-frontend/src/App.jsx
+++ b/inmobiliaria-frontend/src/App.jsx
@@ -25,37 +25,39 @@ function App({ setModo, modo }) {
   return (
     // Envuelve toda la app en un enrutador para habilitar navegación por URLs
     <BrowserRouter>
-      {/* Barra de navegación, recibe props para cambiar el modo claro/oscuro */}
-      <Navbar setModo={setModo} modo={modo} />
-      <Toolbar />
-      {/* Contenido principal */}
-      <Box component="main" sx={{ pb: 8 }}>
-        {/* Define las rutas disponibles */}
-        <Routes>
-          {/* Ruta de inicio */}
-          <Route path="/" element={<Home />} />
-          {/* Autenticación */}
-          <Route path="/login" element={<Login />} />
-          <Route path="/registro" element={<Register />} />
-          <Route path="/recuperar" element={<RecuperarPassword />} />
-          <Route path="/restablecer/:token" element={<RestablecerPassword />} />
-          {/* Verificación de cuenta por token */}
-          <Route path="/verificar/:token" element={<VerificarCuenta />} />
-          {/* Detalle de una propiedad específica */}
-          <Route path="/propiedad/:id" element={<DetallePropiedad />} />
-          {/* Página de contacto */}
-          <Route path="/contacto" element={<Contacto />} />
-          {/* Favoritos del usuario */}
-          <Route path="/favoritos" element={<Favoritos />} />
-          {/* Rutas protegidas solo para administradores */}
-          <Route path="/admin" element={<RutaPrivadaAdmin><AdminPanel /></RutaPrivadaAdmin>} />
-          <Route path="/admin/usuarios" element={<RutaPrivadaAdmin><UsuariosAdmin /></RutaPrivadaAdmin>} />
-          <Route path="/admin/mensajes" element={<RutaPrivadaAdmin><MensajesAdmin /></RutaPrivadaAdmin>} />
-          {/* Ruta para manejar páginas no encontradas */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+      <Box sx={{ display: 'flex', minHeight: '100vh', flexDirection: 'column' }}>
+        {/* Barra de navegación, recibe props para cambiar el modo claro/oscuro */}
+        <Navbar setModo={setModo} modo={modo} />
+        <Toolbar />
+        {/* Contenido principal */}
+        <Box component="main" sx={{ flexGrow: 1 }}>
+          {/* Define las rutas disponibles */}
+          <Routes>
+            {/* Ruta de inicio */}
+            <Route path="/" element={<Home />} />
+            {/* Autenticación */}
+            <Route path="/login" element={<Login />} />
+            <Route path="/registro" element={<Register />} />
+            <Route path="/recuperar" element={<RecuperarPassword />} />
+            <Route path="/restablecer/:token" element={<RestablecerPassword />} />
+            {/* Verificación de cuenta por token */}
+            <Route path="/verificar/:token" element={<VerificarCuenta />} />
+            {/* Detalle de una propiedad específica */}
+            <Route path="/propiedad/:id" element={<DetallePropiedad />} />
+            {/* Página de contacto */}
+            <Route path="/contacto" element={<Contacto />} />
+            {/* Favoritos del usuario */}
+            <Route path="/favoritos" element={<Favoritos />} />
+            {/* Rutas protegidas solo para administradores */}
+            <Route path="/admin" element={<RutaPrivadaAdmin><AdminPanel /></RutaPrivadaAdmin>} />
+            <Route path="/admin/usuarios" element={<RutaPrivadaAdmin><UsuariosAdmin /></RutaPrivadaAdmin>} />
+            <Route path="/admin/mensajes" element={<RutaPrivadaAdmin><MensajesAdmin /></RutaPrivadaAdmin>} />
+            {/* Ruta para manejar páginas no encontradas */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Box>
+        <Footer />
       </Box>
-      <Footer />
     </BrowserRouter>
   );
 }

--- a/inmobiliaria-frontend/src/components/Footer.jsx
+++ b/inmobiliaria-frontend/src/components/Footer.jsx
@@ -5,14 +5,11 @@ function Footer() {
     <Box
       component="footer"
       sx={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        width: '100%',
         bgcolor: "primary.main",
         color: "primary.contrastText",
         p: 2,
         textAlign: "center",
+        mt: "auto",
       }}
     >
       <Typography variant="body2">


### PR DESCRIPTION
## Summary
- make footer part of flex layout instead of fixed
- wrap app in flex column so footer stays at bottom and doesn't overlap cards

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2e81576f48325833c6d5f4ec27ae5