### PR TITLE
Add property image gallery

### DIFF
--- a/inmobiliaria-backend/controllers/propiedad.controller.js
+++ b/inmobiliaria-backend/controllers/propiedad.controller.js
@@ -2,6 +2,7 @@
 const Propiedad = require("../models/propiedad.model");
 const path = require("path");
 const supabase = require("../config/supabase");
+const ImagenPropiedad = require("../models/imagenPropiedad.model");
 
 // GET /api/propiedades
 // Obtener todas las propiedades con filtros opcionales
@@ -39,8 +40,15 @@ const obtenerPropiedadPorId = (req, res) => {
     } else if (resultados.rows.length === 0) {
       res.status(404).json({ mensaje: "Propiedad no encontrada" });
     } else {
-      // `rows` contiene las propiedades obtenidas; devolvemos la primera.
-      res.json(resultados.rows[0]);
+      const propiedad = resultados.rows[0];
+      ImagenPropiedad.obtenerImagenesPorPropiedad(id, (imgErr, imgRes) => {
+        if (imgErr) {
+          console.error(imgErr);
+          return res.status(500).json({ error: "Error al obtener imágenes" });
+        }
+        propiedad.imagenes = imgRes.rows;
+        res.json(propiedad);
+      });
     }
   });
 };
@@ -50,37 +58,59 @@ const obtenerPropiedadPorId = (req, res) => {
 const crearPropiedad = async (req, res) => {
   // req.body contiene los datos del formulario.
   const nuevaPropiedad = req.body;
+  const archivos = req.files || [];
+  const urls = [];
 
-  // Si llega una imagen, se sube a Supabase Storage y se guarda la URL pública.
-  if (req.file) {
-    const extension = path.extname(req.file.originalname);
-    const nombreArchivo = `${Date.now()}${extension}`;
+  for (const file of archivos) {
+    const extension = path.extname(file.originalname);
+    const nombreArchivo = `${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}${extension}`;
 
     const { error } = await supabase.storage
       .from("uploads")
-      .upload(nombreArchivo, req.file.buffer, {
-        contentType: req.file.mimetype,
-      });
+      .upload(nombreArchivo, file.buffer, { contentType: file.mimetype });
 
     if (error) {
       console.error(error);
-      return res.status(500).json({ error: "No se pudo subir la imagen" });
+    } else {
+      const { data } = supabase.storage
+        .from("uploads")
+        .getPublicUrl(nombreArchivo);
+      urls.push(data.publicUrl);
     }
-
-    const { data } = supabase.storage.from("uploads").getPublicUrl(nombreArchivo);
-    nuevaPropiedad.imagen_destacada = data.publicUrl;
   }
 
-  // Llama al modelo para guardar la nueva propiedad.
-  Propiedad.crearPropiedad(nuevaPropiedad, (err, resultado) => {
+  if (urls.length > 0) {
+    nuevaPropiedad.imagen_destacada = urls[0];
+  }
+
+  Propiedad.crearPropiedad(nuevaPropiedad, async (err, resultado) => {
     if (err) {
       console.error(err);
       res.status(500).json({ error: "No se pudo crear la propiedad" });
     } else {
+      const propiedadId = resultado.rows[0].id;
+      await Promise.all(
+        urls.map((url, index) =>
+          new Promise((resolve, reject) => {
+            ImagenPropiedad.agregarImagen(
+              propiedadId,
+              url,
+              nuevaPropiedad.titulo || "",
+              index,
+              (imgErr) => {
+                if (imgErr) reject(imgErr);
+                else resolve();
+              }
+            );
+          })
+        )
+      ).catch((e) => console.error(e));
+
       res.status(201).json({
         mensaje: "Propiedad creada correctamente",
-        //Si se guarda bien, devuelve el ID del nuevo registro.
-        id: resultado.insertId,
+        id: propiedadId,
       });
     }
   });
@@ -93,25 +123,59 @@ const actualizarPropiedad = async (req, res) => {
   const id = req.params.id;
   // Recibe datos nuevos desde el frontend (req.body)
   const datosActualizados = req.body;
+  const archivos = req.files || [];
+  const urls = [];
 
-  // Si el usuario envía una nueva imagen, la sube y reemplaza la existente.
-  if (req.file) {
-    const extension = path.extname(req.file.originalname);
-    const nombreArchivo = `${Date.now()}${extension}`;
+  for (const file of archivos) {
+    const extension = path.extname(file.originalname);
+    const nombreArchivo = `${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}${extension}`;
 
     const { error } = await supabase.storage
       .from("uploads")
-      .upload(nombreArchivo, req.file.buffer, {
-        contentType: req.file.mimetype,
-      });
+      .upload(nombreArchivo, file.buffer, { contentType: file.mimetype });
 
     if (error) {
       console.error(error);
-      return res.status(500).json({ error: "No se pudo subir la imagen" });
+    } else {
+      const { data } = supabase.storage
+        .from("uploads")
+        .getPublicUrl(nombreArchivo);
+      urls.push(data.publicUrl);
     }
+  }
 
-    const { data } = supabase.storage.from("uploads").getPublicUrl(nombreArchivo);
-    datosActualizados.imagen_destacada = data.publicUrl;
+  if (urls.length > 0) {
+    datosActualizados.imagen_destacada = urls[0];
+    let offset = 0;
+    try {
+      const existentes = await new Promise((resolve, reject) => {
+        ImagenPropiedad.obtenerImagenesPorPropiedad(id, (err, res) => {
+          if (err) reject(err);
+          else resolve(res.rows.length);
+        });
+      });
+      offset = existentes;
+    } catch (e) {
+      console.error(e);
+    }
+    await Promise.all(
+      urls.map((url, index) =>
+        new Promise((resolve, reject) => {
+          ImagenPropiedad.agregarImagen(
+            id,
+            url,
+            datosActualizados.titulo || "",
+            offset + index,
+            (imgErr) => {
+              if (imgErr) reject(imgErr);
+              else resolve();
+            }
+          );
+        })
+      )
+    ).catch((e) => console.error(e));
   }
 
   Propiedad.actualizarPropiedad(id, datosActualizados, (err, resultado) => {

--- a/inmobiliaria-backend/models/imagenPropiedad.model.js
+++ b/inmobiliaria-backend/models/imagenPropiedad.model.js
@@ -1,0 +1,19 @@
+const db = require('../config/db');
+
+// Insert a single image for a property
+const agregarImagen = (propertyId, url, alt, order, callback) => {
+  const sql = 'INSERT INTO property_images (property_id, url, alt, "order") VALUES ($1, $2, $3, $4)';
+  const valores = [propertyId, url, alt || '', order];
+  db.query(sql, valores, callback);
+};
+
+// Retrieve images for a given property ordered by the order column
+const obtenerImagenesPorPropiedad = (propertyId, callback) => {
+  const sql = 'SELECT id, url, alt, "order" FROM property_images WHERE property_id = $1 ORDER BY "order"';
+  db.query(sql, [propertyId], callback);
+};
+
+module.exports = {
+  agregarImagen,
+  obtenerImagenesPorPropiedad,
+};

--- a/inmobiliaria-backend/models/propiedad.model.js
+++ b/inmobiliaria-backend/models/propiedad.model.js
@@ -52,7 +52,7 @@ const crearPropiedad = (data, callback) => {
     ) VALUES (
       $1, $2, $3, $4, $5, $6, $7,
       $8, $9, $10, $11, $12, $13
-    )
+    ) RETURNING id
   `;
 
   const valores = [

--- a/inmobiliaria-backend/routes/propiedad.routes.js
+++ b/inmobiliaria-backend/routes/propiedad.routes.js
@@ -16,8 +16,8 @@ router.get('/', controlador.obtenerPropiedades);
 router.get('/:id', controlador.obtenerPropiedadPorId);
 
 // Rutas protegidas (token + admin)
-router.post('/', verifyToken, soloAdmin, upload.single('imagen'), controlador.crearPropiedad);
-router.put('/:id', verifyToken, soloAdmin, upload.single('imagen'), controlador.actualizarPropiedad);
+router.post('/', verifyToken, soloAdmin, upload.array('imagenes'), controlador.crearPropiedad);
+router.put('/:id', verifyToken, soloAdmin, upload.array('imagenes'), controlador.actualizarPropiedad);
 router.delete('/:id', verifyToken, soloAdmin, controlador.eliminarPropiedad);
 
 module.exports = router;

--- a/inmobiliaria-frontend/src/pages/AdminPanel.jsx
+++ b/inmobiliaria-frontend/src/pages/AdminPanel.jsx
@@ -30,7 +30,7 @@ function AdminPanel() {
     banos: "",
     cochera: "",
     m2: "",
-    imagen: null,
+    imagenes: null,
   });
   const [editandoId, setEditandoId] = useState(null);
   const [editData, setEditData] = useState({});
@@ -63,10 +63,13 @@ function AdminPanel() {
     e.preventDefault();
     const formData = new FormData();
     Object.entries(nueva).forEach(([key, val]) => {
-      if (val !== null && val !== undefined && val !== "") {
+      if (key !== "imagenes" && val !== null && val !== undefined && val !== "") {
         formData.append(key, val);
       }
     });
+    if (nueva.imagenes) {
+      Array.from(nueva.imagenes).forEach((img) => formData.append("imagenes", img));
+    }
 
     axios
       .post("https://inmobiliaria-proyecto.onrender.com/api/propiedades", formData, {
@@ -86,7 +89,7 @@ function AdminPanel() {
           banos: "",
           cochera: "",
           m2: "",
-          imagen: null,
+          imagenes: null,
         });
       })
       .catch(() => alert("Error al crear propiedad"));
@@ -256,13 +259,14 @@ function AdminPanel() {
             </Grid>
             <Grid item xs={12} sm={6}>
               <FormControl fullWidth>
-                <InputLabel shrink htmlFor="imagen"></InputLabel>
+                <InputLabel shrink htmlFor="imagenes"></InputLabel>
                 <input
                   type="file"
                   accept="image/*"
-                  id="imagen"
+                  id="imagenes"
+                  multiple
                   onChange={(e) =>
-                    setNueva({ ...nueva, imagen: e.target.files[0] })
+                    setNueva({ ...nueva, imagenes: e.target.files })
                   }
                 />
               </FormControl>

--- a/inmobiliaria-frontend/src/pages/DetallePropiedad.jsx
+++ b/inmobiliaria-frontend/src/pages/DetallePropiedad.jsx
@@ -12,6 +12,7 @@ import {
   CircularProgress,
   Alert,
   Divider,
+  Dialog,
 } from "@mui/material";
 
 function DetallePropiedad() {
@@ -20,6 +21,8 @@ function DetallePropiedad() {
   const [error, setError] = useState("");
   const [esFavorito, setEsFavorito] = useState(false);
   const [mensaje, setMensaje] = useState("");
+  const [indiceImagen, setIndiceImagen] = useState(0);
+  const [lightboxAbierto, setLightboxAbierto] = useState(false);
   const usuario = JSON.parse(localStorage.getItem("usuario"));
   const puedeFavoritos = ["cliente", "usuario"].includes(usuario?.rol);
   const navigate = useNavigate();
@@ -77,15 +80,49 @@ function DetallePropiedad() {
       </Box>
     );
 
+  const imagenes =
+    propiedad.imagenes && propiedad.imagenes.length > 0
+      ? propiedad.imagenes
+      : [{ url: propiedad.imagen_destacada, alt: propiedad.titulo }];
+
   return (
     <Box sx={{ p: 4, maxWidth: 900, mx: "auto" }}>
       <Card sx={{ borderRadius: 2, boxShadow: 4 }}>
-        <CardMedia
-          component="img"
-          height="400"
-          image={propiedad.imagen_destacada}
-          alt={propiedad.titulo}
-        />
+        <Box>
+          <Box
+            sx={{ cursor: "pointer" }}
+            onClick={() => setLightboxAbierto(true)}
+          >
+            <img
+              src={imagenes[indiceImagen].url}
+              alt={imagenes[indiceImagen].alt}
+              style={{ width: "100%", height: 400, objectFit: "cover" }}
+            />
+          </Box>
+          <Box sx={{ display: "flex", mt: 1, gap: 1, overflowX: "auto" }}>
+            {imagenes.map((img, idx) => (
+              <Box
+                key={idx}
+                onClick={() => setIndiceImagen(idx)}
+                sx={{
+                  width: 80,
+                  height: 80,
+                  border:
+                    idx === indiceImagen
+                      ? "2px solid #1976d2"
+                      : "1px solid #ccc",
+                  cursor: "pointer",
+                }}
+              >
+                <img
+                  src={img.url}
+                  alt={img.alt}
+                  style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                />
+              </Box>
+            ))}
+          </Box>
+        </Box>
 
         <CardContent>
           <Typography variant="h4" gutterBottom>
@@ -144,13 +181,24 @@ function DetallePropiedad() {
               {esFavorito ? "Quitar de Favoritos" : "Agregar a Favoritos"}
             </Button>
           </Box>
-          {mensaje && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              {mensaje}
-            </Alert>
-          )}
+        {mensaje && (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            {mensaje}
+          </Alert>
+        )}
         </CardContent>
       </Card>
+      <Dialog
+        open={lightboxAbierto}
+        onClose={() => setLightboxAbierto(false)}
+        maxWidth="lg"
+      >
+        <img
+          src={imagenes[indiceImagen].url}
+          alt={imagenes[indiceImagen].alt}
+          style={{ width: "100%", height: "100%", objectFit: "contain" }}
+        />
+      </Dialog>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- support multiple property images in backend with Supabase uploads and new `property_images` table helper
- expose image gallery on property detail and accept multiple images in admin panel

## Testing
- `npm test` *(backend: jest not found)*
- `npm test` *(frontend: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b491a3e1848325b11f4191e7c88ef7