### PR TITLE
Add admin image ordering and deletion

### DIFF
--- a/inmobiliaria-backend/models/imagenPropiedad.model.js
+++ b/inmobiliaria-backend/models/imagenPropiedad.model.js
@@ -1,0 +1,37 @@
+const db = require('../config/db');
+
+// Insert a single image for a property
+const agregarImagen = (propertyId, url, alt, order, callback) => {
+  const sql = 'INSERT INTO property_images (property_id, url, alt, "order") VALUES ($1, $2, $3, $4)';
+  const valores = [propertyId, url, alt || '', order];
+  db.query(sql, valores, callback);
+};
+
+// Retrieve images for a given property ordered by the order column
+const obtenerImagenesPorPropiedad = (propertyId, callback) => {
+  const sql = 'SELECT id, url, alt, "order" FROM property_images WHERE property_id = $1 ORDER BY "order"';
+  db.query(sql, [propertyId], callback);
+};
+
+// Delete an image by its ID
+const eliminarImagen = (id, callback) => {
+  const sql = 'DELETE FROM property_images WHERE id = $1';
+  db.query(sql, [id], callback);
+};
+
+// Update order of images for a property given an array of image IDs
+const actualizarOrdenImagenes = (propertyId, ids, callback) => {
+  const queries = ids.map((imgId, index) =>
+    db.query('UPDATE property_images SET "order" = $1 WHERE id = $2 AND property_id = $3', [index, imgId, propertyId])
+  );
+  Promise.all(queries)
+    .then(() => callback(null))
+    .catch((err) => callback(err));
+};
+
+module.exports = {
+  agregarImagen,
+  obtenerImagenesPorPropiedad,
+  eliminarImagen,
+  actualizarOrdenImagenes,
+};

--- a/inmobiliaria-backend/models/propiedad.model.js
+++ b/inmobiliaria-backend/models/propiedad.model.js
@@ -52,7 +52,7 @@ const crearPropiedad = (data, callback) => {
     ) VALUES (
       $1, $2, $3, $4, $5, $6, $7,
       $8, $9, $10, $11, $12, $13
-    )
+    ) RETURNING id
   `;
 
   const valores = [

--- a/inmobiliaria-backend/routes/propiedad.routes.js
+++ b/inmobiliaria-backend/routes/propiedad.routes.js
@@ -16,9 +16,11 @@ router.get('/', controlador.obtenerPropiedades);
 router.get('/:id', controlador.obtenerPropiedadPorId);
 
 // Rutas protegidas (token + admin)
-router.post('/', verifyToken, soloAdmin, upload.single('imagen'), controlador.crearPropiedad);
-router.put('/:id', verifyToken, soloAdmin, upload.single('imagen'), controlador.actualizarPropiedad);
+router.post('/', verifyToken, soloAdmin, upload.array('imagenes'), controlador.crearPropiedad);
+router.put('/:id', verifyToken, soloAdmin, upload.array('imagenes'), controlador.actualizarPropiedad);
 router.delete('/:id', verifyToken, soloAdmin, controlador.eliminarPropiedad);
+router.delete('/:id/imagenes/:imageId', verifyToken, soloAdmin, controlador.eliminarImagen);
+router.put('/:id/imagenes/orden', verifyToken, soloAdmin, controlador.actualizarOrdenImagenes);
 
 module.exports = router;
 

--- a/inmobiliaria-frontend/src/pages/AdminPanel.jsx
+++ b/inmobiliaria-frontend/src/pages/AdminPanel.jsx
@@ -30,10 +30,11 @@ function AdminPanel() {
     banos: "",
     cochera: "",
     m2: "",
-    imagen: null,
+    imagenes: null,
   });
   const [editandoId, setEditandoId] = useState(null);
   const [editData, setEditData] = useState({});
+  const [dragIndex, setDragIndex] = useState(null);
   const token = localStorage.getItem("token");
 
   const [nuevoAdmin, setNuevoAdmin] = useState({
@@ -63,10 +64,13 @@ function AdminPanel() {
     e.preventDefault();
     const formData = new FormData();
     Object.entries(nueva).forEach(([key, val]) => {
-      if (val !== null && val !== undefined && val !== "") {
+      if (key !== "imagenes" && val !== null && val !== undefined && val !== "") {
         formData.append(key, val);
       }
     });
+    if (nueva.imagenes) {
+      Array.from(nueva.imagenes).forEach((img) => formData.append("imagenes", img));
+    }
 
     axios
       .post("https://inmobiliaria-proyecto.onrender.com/api/propiedades", formData, {
@@ -86,15 +90,19 @@ function AdminPanel() {
           banos: "",
           cochera: "",
           m2: "",
-          imagen: null,
+          imagenes: null,
         });
       })
       .catch(() => alert("Error al crear propiedad"));
   };
 
   const handleEditClick = (prop) => {
-    setEditandoId(prop.id);
-    setEditData({ ...prop });
+    axios
+      .get(`https://inmobiliaria-proyecto.onrender.com/api/propiedades/${prop.id}`)
+      .then((res) => {
+        setEditandoId(prop.id);
+        setEditData(res.data);
+      });
   };
 
   const handleEditChange = (e) => {
@@ -106,15 +114,74 @@ function AdminPanel() {
   };
 
   const handleSaveEdit = (id) => {
+    const formData = new FormData();
+    Object.entries(editData).forEach(([key, val]) => {
+      if (
+        key !== "imagenes" &&
+        key !== "nuevasImagenes" &&
+        val !== null &&
+        val !== undefined &&
+        val !== ""
+      ) {
+        formData.append(key, val);
+      }
+    });
+    if (editData.nuevasImagenes) {
+      Array.from(editData.nuevasImagenes).forEach((img) =>
+        formData.append("imagenes", img)
+      );
+    }
     axios
-      .put(`https://inmobiliaria-proyecto.onrender.com/api/propiedades/${id}`, editData, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      .put(
+        `https://inmobiliaria-proyecto.onrender.com/api/propiedades/${id}`,
+        formData,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "multipart/form-data",
+          },
+        }
+      )
       .then(() => {
         setEditandoId(null);
         cargarPropiedades();
       })
       .catch(() => alert("Error al actualizar"));
+  };
+
+  const handleDragStart = (index) => {
+    setDragIndex(index);
+  };
+
+  const handleDrop = (index) => {
+    if (dragIndex === null) return;
+    const items = Array.from(editData.imagenes || []);
+    const [moved] = items.splice(dragIndex, 1);
+    items.splice(index, 0, moved);
+    setDragIndex(null);
+    setEditData((prev) => ({ ...prev, imagenes: items }));
+    axios
+      .put(
+        `https://inmobiliaria-proyecto.onrender.com/api/propiedades/${editandoId}/imagenes/orden`,
+        { orden: items.map((i) => i.id) },
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      .catch(() => alert("Error al reordenar"));
+  };
+
+  const handleImageDelete = (imgId) => {
+    axios
+      .delete(
+        `https://inmobiliaria-proyecto.onrender.com/api/propiedades/${editandoId}/imagenes/${imgId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      .then(() => {
+        setEditData((prev) => ({
+          ...prev,
+          imagenes: prev.imagenes.filter((i) => i.id !== imgId),
+        }));
+      })
+      .catch(() => alert("Error al eliminar imagen"));
   };
 
   const handleCancelEdit = () => {
@@ -256,13 +323,14 @@ function AdminPanel() {
             </Grid>
             <Grid item xs={12} sm={6}>
               <FormControl fullWidth>
-                <InputLabel shrink htmlFor="imagen"></InputLabel>
+                <InputLabel shrink htmlFor="imagenes"></InputLabel>
                 <input
                   type="file"
                   accept="image/*"
-                  id="imagen"
+                  id="imagenes"
+                  multiple
                   onChange={(e) =>
-                    setNueva({ ...nueva, imagen: e.target.files[0] })
+                    setNueva({ ...nueva, imagenes: e.target.files })
                   }
                 />
               </FormControl>
@@ -417,6 +485,47 @@ function AdminPanel() {
                         label="Metros cuadrados"
                         value={editData.m2}
                         onChange={handleEditChange}
+                        sx={{ mb: 1 }}
+                      />
+                      {editData.imagenes && (
+                        <Box
+                          display="flex"
+                          gap={1}
+                          flexWrap="wrap"
+                          sx={{ mb: 1 }}
+                        >
+                          {editData.imagenes.map((img, idx) => (
+                            <Box
+                              key={img.id}
+                              draggable
+                              onDragStart={() => handleDragStart(idx)}
+                              onDragOver={(e) => e.preventDefault()}
+                              onDrop={() => handleDrop(idx)}
+                              sx={{ position: "relative" }}
+                            >
+                              <img
+                                src={img.url}
+                                alt={img.alt}
+                                width={80}
+                                height={80}
+                              />
+                              <IconButton
+                                size="small"
+                                onClick={() => handleImageDelete(img.id)}
+                                sx={{ position: "absolute", top: 0, right: 0 }}
+                              >
+                                <Delete fontSize="small" />
+                              </IconButton>
+                            </Box>
+                          ))}
+                        </Box>
+                      )}
+                      <TextField
+                        type="file"
+                        inputProps={{ multiple: true }}
+                        onChange={(e) =>
+                          setEditData({ ...editData, nuevasImagenes: e.target.files })
+                        }
                         sx={{ mb: 1 }}
                       />
                       <Box display="flex" gap={1}>

--- a/inmobiliaria-frontend/src/pages/DetallePropiedad.jsx
+++ b/inmobiliaria-frontend/src/pages/DetallePropiedad.jsx
@@ -12,6 +12,7 @@ import {
   CircularProgress,
   Alert,
   Divider,
+  Dialog,
 } from "@mui/material";
 
 function DetallePropiedad() {
@@ -20,6 +21,8 @@ function DetallePropiedad() {
   const [error, setError] = useState("");
   const [esFavorito, setEsFavorito] = useState(false);
   const [mensaje, setMensaje] = useState("");
+  const [indiceImagen, setIndiceImagen] = useState(0);
+  const [lightboxAbierto, setLightboxAbierto] = useState(false);
   const usuario = JSON.parse(localStorage.getItem("usuario"));
   const puedeFavoritos = ["cliente", "usuario"].includes(usuario?.rol);
   const navigate = useNavigate();
@@ -77,15 +80,49 @@ function DetallePropiedad() {
       </Box>
     );
 
+  const imagenes =
+    propiedad.imagenes && propiedad.imagenes.length > 0
+      ? propiedad.imagenes
+      : [{ url: propiedad.imagen_destacada, alt: propiedad.titulo }];
+
   return (
     <Box sx={{ p: 4, maxWidth: 900, mx: "auto" }}>
       <Card sx={{ borderRadius: 2, boxShadow: 4 }}>
-        <CardMedia
-          component="img"
-          height="400"
-          image={propiedad.imagen_destacada}
-          alt={propiedad.titulo}
-        />
+        <Box>
+          <Box
+            sx={{ cursor: "pointer" }}
+            onClick={() => setLightboxAbierto(true)}
+          >
+            <img
+              src={imagenes[indiceImagen].url}
+              alt={imagenes[indiceImagen].alt}
+              style={{ width: "100%", height: 400, objectFit: "cover" }}
+            />
+          </Box>
+          <Box sx={{ display: "flex", mt: 1, gap: 1, overflowX: "auto" }}>
+            {imagenes.map((img, idx) => (
+              <Box
+                key={idx}
+                onClick={() => setIndiceImagen(idx)}
+                sx={{
+                  width: 80,
+                  height: 80,
+                  border:
+                    idx === indiceImagen
+                      ? "2px solid #1976d2"
+                      : "1px solid #ccc",
+                  cursor: "pointer",
+                }}
+              >
+                <img
+                  src={img.url}
+                  alt={img.alt}
+                  style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                />
+              </Box>
+            ))}
+          </Box>
+        </Box>
 
         <CardContent>
           <Typography variant="h4" gutterBottom>
@@ -144,13 +181,24 @@ function DetallePropiedad() {
               {esFavorito ? "Quitar de Favoritos" : "Agregar a Favoritos"}
             </Button>
           </Box>
-          {mensaje && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              {mensaje}
-            </Alert>
-          )}
+        {mensaje && (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            {mensaje}
+          </Alert>
+        )}
         </CardContent>
       </Card>
+      <Dialog
+        open={lightboxAbierto}
+        onClose={() => setLightboxAbierto(false)}
+        maxWidth="lg"
+      >
+        <img
+          src={imagenes[indiceImagen].url}
+          alt={imagenes[indiceImagen].alt}
+          style={{ width: "100%", height: "100%", objectFit: "contain" }}
+        />
+      </Dialog>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- allow deleting and reordering property images with new backend routes
- manage gallery in admin panel with drag & drop and file uploads when editing

## Testing
- `npm test` (backend: jest not found)
- `npm test` (frontend: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b491a3e1848325b11f4191e7c88ef7